### PR TITLE
loggly has changed how they treat the URL encoding

### DIFF
--- a/search.go
+++ b/search.go
@@ -157,7 +157,7 @@ func getSlackMessage(message string, query string, since string, to string, titl
 			Fields:     fields,
 			MarkdownIn: []string{"fields"},
 			Title:      title,
-			TitleLink:  "https://" + looglyAccount + ".loggly.com/search#terms=" + url.QueryEscape(query) + "&from=" + url.QueryEscape(since) + "&until=" + url.QueryEscape(to),
+			TitleLink:  "https://" + looglyAccount + ".loggly.com/search#terms=" + url.PathEscape(query) + "&from=" + url.PathEscape(since) + "&until=" + url.PathEscape(to),
 		}
 		params.Attachments = []slack.Attachment{attachment}
 		result[i] = params


### PR DESCRIPTION
Even though the "standard" should be to use the `+` as scape after the `?`in the query, they have changed something and now they use the `%20` instead. Links were broken.
See here https://stackoverflow.com/questions/1634271/url-encoding-the-space-character-or-20